### PR TITLE
Fix misnamed env var

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ runs:
   image: "Dockerfile"
   env:
     TERRAFORM_TOKEN: ${{ inputs.terraform-token }}
-    TERRAFORM_ORG: ${{ inputs.terraform-org }}
+    TERRAFORM_ORGANIZATION: ${{ inputs.terraform-org }}
     TERRAFORM_WORKSPACE: ${{ inputs.terraform-workspace }}
     TERRAFORM_VARIABLE_NAME: ${{ inputs.terraform-variable-name }}
     TERRAFORM_VARIABLE_VALUE: ${{ inputs.terraform-variable-value }}


### PR DESCRIPTION
## Summary
- I used the wrong environment variable name for `TERRAFORM_ORGANIZATION` causing deployments to fail. https://github.com/xmtp/example-notification-server-go/actions/runs/4166645037/jobs/7211238298