### PR TITLE
Add git to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ ARG GO_VERSION=1.19
 
 FROM golang:${GO_VERSION}-alpine
 WORKDIR /app
+RUN apk add --no-cache git
 COPY go.mod .
 COPY go.sum .
 RUN go mod download


### PR DESCRIPTION
## Summary
Hopefully last issue.

I realized that I hadn't exercised the code that runs Git inside the Docker container. Alpine, of course, comes with basically nothing and doesn't include Git. Added the binary to the Docker Image.