### PR TITLE
Set explicit default for timeout input in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,7 @@ inputs:
     description: "The title of the terraform run. If not specified, defaults to latest commit message"
   timeout:
     description: "The timeout for the terraform run. If not specified, defaults to 15 minutes"
+    default: "15m"
 runs:
   using: "docker"
   image: "Dockerfile"


### PR DESCRIPTION
Failing in workflows that don't currently specify a `timeout` input, so this PR adds a default for the input in action.yml:

> invalid argument for flag `--timeout' (expected time.Duration): time: invalid duration ""
> 2024-02-22T22:58:31.354Z	FATAL	deploy/main.go:26	Could not parse options	{"error": "invalid argument for flag `--timeout' (expected time.Duration): time: invalid duration \"\""}